### PR TITLE
Replace express with native node calls

### DIFF
--- a/Microsoft.AspNet.NodeServices/Content/Node/entrypoint-http.js
+++ b/Microsoft.AspNet.NodeServices/Content/Node/entrypoint-http.js
@@ -20,7 +20,8 @@ var server = http.createServer(function(req, res) {
             if (!hasSentResult) {
                 hasSentResult = true;
                 if (errorValue) {
-                    res.status(500).send(errorValue);
+                    res.statusCode = 500;
+                    res.end(errorValue.toString());
                 } else if (typeof successValue !== 'string') {
                     // Arbitrary object/number/etc - JSON-serialize it
                     res.setHeader('Content-Type', 'application/json');

--- a/Microsoft.AspNet.NodeServices/Content/Node/entrypoint-http.js
+++ b/Microsoft.AspNet.NodeServices/Content/Node/entrypoint-http.js
@@ -21,7 +21,12 @@ var server = http.createServer(function(req, res) {
                 hasSentResult = true;
                 if (errorValue) {
                     res.statusCode = 500;
-                    res.end(errorValue.toString());
+                    
+                    if (errorValue.stack) {
+                      res.end(errorValue.stack);
+                    } else {
+                      res.end(errorValue.toString());
+                    }
                 } else if (typeof successValue !== 'string') {
                     // Arbitrary object/number/etc - JSON-serialize it
                     res.setHeader('Content-Type', 'application/json');

--- a/Microsoft.AspNet.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/Microsoft.AspNet.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Microsoft.AspNet.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/Microsoft.AspNet.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -29,6 +29,11 @@ namespace Microsoft.AspNet.NodeServices {
                 var payload = new StringContent(payloadJson, Encoding.UTF8, "application/json");
                 var response = await client.PostAsync("http://localhost:" + this._portNumber, payload);
                 var responseString = await response.Content.ReadAsStringAsync();
+                
+                if (response.StatusCode != HttpStatusCode.OK) {
+                    throw new Exception("Node module responded with error: " + responseString);   
+                }
+                
                 var responseIsJson = response.Content.Headers.ContentType.MediaType == "application/json";
                 if (responseIsJson) {
                     return JsonConvert.DeserializeObject<T>(responseString);


### PR DESCRIPTION
I updated the old express calls to use the ones provided by the base node framework. 

There are two other changes I wanted to suggest as well. If a module is not found an error is thrown which results in a non-graceful shutdown of the process. This in turn results in a generic exception in .NET which does not give any indication of the error that actually occurred within the node process.

```node
throw new Error('The module "' + resolvedPath + '" has no export named "' + bodyJson.exportedFunctionName + '"');
``` 

This also applies to the logic used in `react-rendering.js`. I would propose ensuring that all errors bubble up to the client without causing the process to end unexpectedly i.e. wrapping the logic inside of a try/catch block and sending the error via the http pipeline before ending the process.

I can submit an additional PR if needed.