### PR TITLE
chore: add js and jsx files to gitignore 

### DIFF
--- a/samples/angular/MusicStore/.gitignore
+++ b/samples/angular/MusicStore/.gitignore
@@ -4,6 +4,7 @@
 /project.lock.json
 /music-db.sqlite
 /Properties/launchSettings.json
+/typings
 
 # Obviously you don't really want your DB to go in wwwroot, but due to https://github.com/aspnet/Microsoft.Data.Sqlite/issues/188
 # it currently does when run from IIS Express. Will resolve this once RC2 is out, which is supposed to eliminate the inconsistency.

--- a/templates/Angular2Spa/.gitignore
+++ b/templates/Angular2Spa/.gitignore
@@ -233,3 +233,7 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# TS compilled files
+/**/*.js
+/**/*.js.map

--- a/templates/ReactReduxSpa/.gitignore
+++ b/templates/ReactReduxSpa/.gitignore
@@ -233,3 +233,9 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# TSX compilled files
+/**/*.jsx
+/**/*.jsx.map
+/**/*.js
+/**/*.js.map

--- a/templates/ReactSpa/.gitignore
+++ b/templates/ReactSpa/.gitignore
@@ -233,3 +233,9 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# TSX compilled files
+/**/*.jsx
+/**/*.jsx.map
+/**/*.js
+/**/*.js.map

--- a/templates/WebApplicationBasic/.gitignore
+++ b/templates/WebApplicationBasic/.gitignore
@@ -233,3 +233,7 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# TS compilled files
+/**/*.js
+/**/*.js.map


### PR DESCRIPTION
This change just to prevent spam in pending changes with visual studio.
All typescript files in sample compiled to js with .map. It not really necessary to store this file in git, so better to ignore it may be