### PR TITLE
bug: Fix error with incorrect import parse5 closes #55

### DIFF
--- a/templates/Angular2Spa/package.json
+++ b/templates/Angular2Spa/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "angular2": "2.0.0-beta.15",
     "angular2-universal": "0.98.1",
+    "parse5": "1.3.2",
     "aspnet-prerendering": "^1.0.1",
     "aspnet-webpack": "^1.0.1",
     "css": "^2.2.1",


### PR DESCRIPTION
Add this specific version of parse5 till ng2 team not update it to latest one. 
Add this only to template since it missing it, and with default install resolve parse5 dependency to latest one (2.1.5).
May be not best fix, but right now it's only solution that come to me.